### PR TITLE
Adicionado um feedback visual após se curar pós batalha

### DIFF
--- a/lib/app/home/tab/status_read.dart
+++ b/lib/app/home/tab/status_read.dart
@@ -82,7 +82,9 @@ class StatusRead extends StatelessWidget {
             ),
             const SizedBox(width: 12),
             IconButton(
-              onPressed: game.healBeforeBattle ? () => game.healSmall() : null,
+              onPressed: game.healBeforeBattle
+                  ? () => game.healSmall(context)
+                  : null,
               tooltip: 'Curar 10 HP',
               icon: const Icon(Icons.healing),
             ),

--- a/lib/core/state/game_state.dart
+++ b/lib/core/state/game_state.dart
@@ -105,6 +105,8 @@ class GameState extends ChangeNotifier {
 
   bool get healBeforeBattle => _healBeforeBattle;
 
+  /// Cura o jogador antes da batalha, aumentando o HP em 10
+  /// Se o HP já estiver no máximo, não faz nada.
   void healSmall(BuildContext context) {
     if (healBeforeBattle) {
       if (player.hp >= player.maxHp) return;

--- a/lib/core/state/game_state.dart
+++ b/lib/core/state/game_state.dart
@@ -105,12 +105,15 @@ class GameState extends ChangeNotifier {
 
   bool get healBeforeBattle => _healBeforeBattle;
 
-  void healSmall() {
+  void healSmall(BuildContext context) {
     if (healBeforeBattle) {
       if (player.hp >= player.maxHp) return;
       player.hp = (player.hp + 10).clamp(0, player.maxHp);
       _healBeforeBattle = false;
       notifyListeners();
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('Curado 10 HP!')));
     }
   }
 

--- a/lib/core/state/game_state.dart
+++ b/lib/core/state/game_state.dart
@@ -111,9 +111,12 @@ class GameState extends ChangeNotifier {
       player.hp = (player.hp + 10).clamp(0, player.maxHp);
       _healBeforeBattle = false;
       notifyListeners();
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(const SnackBar(content: Text('Curado 10 HP!')));
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Curado 10 HP!'),
+          backgroundColor: Colors.green,
+        ),
+      );
     }
   }
 


### PR DESCRIPTION
# Descrição

**Melhorias na Experiência do Usuário:**

* O método `healSmall` em `GameState` agora exibe uma barra de ferramentas verde com a mensagem "Curado 10 HP!" quando a cura é bem-sucedida, fornecendo um feedback imediato ao usuário.

**Atualizações de Código para Passagem de Contexto:**

* O método `healSmall` agora requer um parâmetro `BuildContext` para exibir a barra de ferramentas, e a chamada correspondente em `StatusRead` passa o `context` ao invocar `healSmall`.

# Ações
- Closes #2 