### PR TITLE
Alternar dark / light mode e salvar preferência

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -23,8 +23,16 @@ class MainApp extends StatelessWidget {
               primarySwatch: a.primaryColor,
               colorScheme: ColorScheme.fromSeed(seedColor: a.primaryColor),
             ),
-            darkTheme: ThemeData.dark(),
-            themeMode: a.themeMode,
+            darkTheme: ThemeData(
+              useMaterial3: true,
+              brightness: Brightness.dark,
+              primarySwatch: a.primaryColor,
+              colorScheme: ColorScheme.fromSeed(
+                seedColor: a.primaryColor,
+                brightness: Brightness.dark,
+              ),
+            ),
+            themeMode: a.themeMode.$1,
             home: Redirect(),
           );
         },

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,6 +1,7 @@
 import 'package:arena_x/app/redirect.dart';
 import 'package:arena_x/core/state/app_state.dart';
 import 'package:arena_x/core/state/game_state.dart';
+import 'package:arena_x/core/theme/app_theme.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
@@ -18,20 +19,8 @@ class MainApp extends StatelessWidget {
         builder: (BuildContext context, AppState a, Widget? child) {
           return MaterialApp(
             title: 'EPIC-like RPG',
-            theme: ThemeData(
-              useMaterial3: true,
-              primarySwatch: a.primaryColor,
-              colorScheme: ColorScheme.fromSeed(seedColor: a.primaryColor),
-            ),
-            darkTheme: ThemeData(
-              useMaterial3: true,
-              brightness: Brightness.dark,
-              primarySwatch: a.primaryColor,
-              colorScheme: ColorScheme.fromSeed(
-                seedColor: a.primaryColor,
-                brightness: Brightness.dark,
-              ),
-            ),
+            theme: AppTheme(a).theme,
+            darkTheme: AppTheme(a).theme,
             themeMode: a.themeMode.$1,
             home: Redirect(),
           );

--- a/lib/app/home/tab/setting_read.dart
+++ b/lib/app/home/tab/setting_read.dart
@@ -24,8 +24,8 @@ class SettingRead extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         SwitchListTile(
-          title: Text(a.themeName),
-          value: a.isDarkMode,
+          title: Text(a.themeMode.$2),
+          value: a.darkMode,
           shape: RoundedRectangleBorder(
             side: BorderSide(
               color: Theme.of(context).colorScheme.surfaceContainerHighest,

--- a/lib/app/home/tab/setting_read.dart
+++ b/lib/app/home/tab/setting_read.dart
@@ -34,9 +34,9 @@ class SettingRead extends StatelessWidget {
           child: Padding(
             padding: const EdgeInsets.all(16.0),
             child: Column(
-              spacing: 8.0,
               children: [
                 WdSwitchTheme(),
+                Divider(),
                 TextFormField(
                   controller: g.playerNameController,
                   decoration: InputDecoration(

--- a/lib/app/home/tab/setting_read.dart
+++ b/lib/app/home/tab/setting_read.dart
@@ -1,14 +1,14 @@
-import 'package:arena_x/core/state/app_state.dart';
 import 'package:arena_x/core/state/game_state.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+
+import '../../../utils/widgets/base/wd_switch_theme.dart';
 
 class SettingRead extends StatelessWidget {
   const SettingRead({super.key});
 
   @override
   Widget build(BuildContext context) {
-    final AppState a = context.watch<AppState>();
     final GameState g = context.watch<GameState>();
     // final List<MaterialColor> materialColors = [
     //   Colors.red,
@@ -21,46 +21,55 @@ class SettingRead extends StatelessWidget {
     // ];
 
     return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
+      crossAxisAlignment: CrossAxisAlignment.center,
       children: [
-        SwitchListTile(
-          title: Text(a.themeMode.$2),
-          value: a.darkMode,
-          shape: RoundedRectangleBorder(
-            side: BorderSide(
-              color: Theme.of(context).colorScheme.surfaceContainerHighest,
-            ),
-            borderRadius: BorderRadius.circular(8.0),
+        CircleAvatar(
+          radius: 40,
+          child: Text(
+            g.player.name.isNotEmpty ? g.player.name[0].toUpperCase() : 'A',
           ),
-          onChanged: (value) {
-            a.toggleTheme();
-          },
         ),
-        Divider(),
-        TextFormField(
-          controller: g.playerNameController,
-          decoration: InputDecoration(
-            labelText: 'Nome do jogador',
-            hintText: 'Digite o nome do jogador',
-            border: OutlineInputBorder(
-              borderSide: BorderSide(
-                color: Theme.of(context).colorScheme.surfaceContainerHighest,
-              ),
-            ),
-          ),
-          onFieldSubmitted: (value) {
-            if (value.trim().isNotEmpty) {
-              g.setPlayerName(value);
-            } else {
-              g.getPlayerName();
-              ScaffoldMessenger.of(context).showSnackBar(
-                SnackBar(
-                  content: Text('O nome do jogador não pode ser vazio!'),
+        SizedBox(height: 8.0),
+        Card(
+          child: Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: Column(
+              spacing: 8.0,
+              children: [
+                WdSwitchTheme(),
+                TextFormField(
+                  controller: g.playerNameController,
+                  decoration: InputDecoration(
+                    labelText: 'Nome do jogador',
+                    hintText: 'Digite o nome do jogador',
+                    border: OutlineInputBorder(
+                      borderSide: BorderSide(
+                        color: Theme.of(
+                          context,
+                        ).colorScheme.surfaceContainerHighest,
+                      ),
+                    ),
+                  ),
+                  onFieldSubmitted: (value) {
+                    if (value.trim().isNotEmpty) {
+                      g.setPlayerName(value);
+                    } else {
+                      g.getPlayerName();
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        SnackBar(
+                          content: Text(
+                            'O nome do jogador não pode ser vazio!',
+                          ),
+                        ),
+                      );
+                    }
+                  },
                 ),
-              );
-            }
-          },
+              ],
+            ),
+          ),
         ),
+        SizedBox(height: 8.0),
         // BlockPicker(
         //   pickerColor: a.primaryColor,
         //   availableColors: [

--- a/lib/core/enum/cache_keys.dart
+++ b/lib/core/enum/cache_keys.dart
@@ -5,6 +5,7 @@ enum CacheKeys {
   xp,
   ouro,
   inventario,
+  lightMode,
 }
 
 extension CacheKeysExtension on CacheKeys {
@@ -22,6 +23,8 @@ extension CacheKeysExtension on CacheKeys {
         return 'ouro';
       case CacheKeys.inventario:
         return 'inventario';
+      case CacheKeys.lightMode:
+        return 'lightMode';
     }
   }
 
@@ -39,6 +42,8 @@ extension CacheKeysExtension on CacheKeys {
         return 'Ouro acumulado pelo jogador';
       case CacheKeys.inventario:
         return 'Itens no inventário do jogador';
+      case CacheKeys.lightMode:
+        return 'Preferência de modo claro/escuro';
     }
   }
 }

--- a/lib/core/state/app_state.dart
+++ b/lib/core/state/app_state.dart
@@ -20,7 +20,7 @@ class AppState extends ChangeNotifier {
       : (ThemeMode.light, 'Modo Claro');
 
   /// Alterna entre o modo claro e escuro, salvando a preferência no cache
-  void toggleTheme() async {
+  Future<void> toggleTheme() async {
     _darkMode = !_darkMode;
     SharedPreferences prefs = await SharedPreferences.getInstance();
     await prefs.setBool(CacheKeys.lightMode.key, !_darkMode);

--- a/lib/core/state/app_state.dart
+++ b/lib/core/state/app_state.dart
@@ -1,5 +1,4 @@
 import 'package:arena_x/core/enum/cache_keys.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 

--- a/lib/core/state/app_state.dart
+++ b/lib/core/state/app_state.dart
@@ -1,39 +1,50 @@
+import 'package:arena_x/core/enum/cache_keys.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 class AppState extends ChangeNotifier {
-  bool _themeIsDark = false;
-
-  bool get isDarkMode => _themeIsDark;
-
-  String get themeName {
-    return _themeIsDark ? 'Modo Escuro' : 'Modo Claro';
+  /// Inicializa o estado do aplicativo e carrega as preferências salvas
+  AppState() {
+    getTheme();
   }
 
-  ThemeMode get themeMode {
-    return _themeIsDark ? ThemeMode.dark : ThemeMode.light;
-  }
+  /// Variável para controlar o modo de tema (claro/escuro)
+  bool _darkMode = false;
 
-  void toggleTheme() {
-    _themeIsDark = !_themeIsDark;
+  /// Getter para verificar se o modo escuro está ativo
+  bool get darkMode => _darkMode;
+
+  /// Retorna o modo de tema atual e sua descrição
+  (ThemeMode, String) get themeMode => _darkMode
+      ? (ThemeMode.dark, 'Modo Escuro')
+      : (ThemeMode.light, 'Modo Claro');
+
+  /// Alterna entre o modo claro e escuro, salvando a preferência no cache
+  void toggleTheme() async {
+    _darkMode = !_darkMode;
+    SharedPreferences prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(CacheKeys.lightMode.key, !_darkMode);
     notifyListeners();
   }
 
-  void getTheme() {
-    ThemeMode mode =
-        defaultTargetPlatform == TargetPlatform.iOS ||
-            defaultTargetPlatform == TargetPlatform.android
-        ? ThemeMode.system
-        : ThemeMode.light;
-    if (mode == ThemeMode.dark) {
-      _themeIsDark = true;
+  /// Carrega a preferência de tema salvo no cache ou usa o tema atual do sistema
+  Future<void> getTheme() async {
+    SharedPreferences prefs = await SharedPreferences.getInstance();
+    bool? mode = prefs.getBool(CacheKeys.lightMode.key);
+    if (mode != null) {
+      if (mode) {
+        _darkMode = false;
+      } else {
+        _darkMode = true;
+      }
     } else {
       Brightness brightness =
           WidgetsBinding.instance.platformDispatcher.platformBrightness;
       if (brightness == Brightness.dark) {
-        _themeIsDark = true;
+        _darkMode = true;
       } else {
-        _themeIsDark = false;
+        _darkMode = false;
       }
     }
     notifyListeners();

--- a/lib/core/theme/app_theme.dart
+++ b/lib/core/theme/app_theme.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+
+import '../state/app_state.dart';
+
+class AppTheme {
+  /// Instância do AppState para acessar as preferências do usuário
+  final AppState a;
+
+  /// Construtor da classe AppTheme
+  AppTheme(this.a);
+
+  /// Retorna o tema claro baseado nas preferências do AppState
+  ThemeData get theme {
+    return ThemeData(
+      useMaterial3: true,
+      primarySwatch: a.primaryColor,
+      brightness: a.darkMode ? Brightness.dark : Brightness.light,
+      cardTheme: CardThemeData(
+        // color: a.primaryColor.shade50,
+        elevation: 0,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(12.0),
+        ),
+      ),
+      textTheme: TextTheme(
+        // Rótulos e legendas
+        labelLarge: TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+        labelMedium: TextStyle(fontSize: 14, fontWeight: FontWeight.w500),
+        labelSmall: TextStyle(fontSize: 12, fontStyle: FontStyle.italic),
+        // Texto do corpo
+        bodyLarge: TextStyle(fontSize: 16),
+        bodyMedium: TextStyle(fontSize: 14),
+        bodySmall: TextStyle(fontSize: 12),
+        // Títulos
+        titleLarge: TextStyle(fontSize: 18, fontWeight: FontWeight.w700),
+        titleMedium: TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
+        titleSmall: TextStyle(fontSize: 14, fontWeight: FontWeight.w500),
+        // Cabeçalhos
+        headlineLarge: TextStyle(fontSize: 26, fontWeight: FontWeight.w600),
+        headlineMedium: TextStyle(fontSize: 22, fontWeight: FontWeight.w600),
+        headlineSmall: TextStyle(fontSize: 20, fontWeight: FontWeight.w500),
+        // Textos de destaque
+        displayLarge: TextStyle(fontSize: 32, fontWeight: FontWeight.w700),
+        displayMedium: TextStyle(fontSize: 28, fontWeight: FontWeight.w700),
+        displaySmall: TextStyle(fontSize: 24, fontWeight: FontWeight.w700),
+      ),
+    );
+  }
+}

--- a/lib/core/theme/app_theme.dart
+++ b/lib/core/theme/app_theme.dart
@@ -15,8 +15,11 @@ class AppTheme {
       useMaterial3: true,
       primarySwatch: a.primaryColor,
       brightness: a.darkMode ? Brightness.dark : Brightness.light,
+      colorScheme: ColorScheme.fromSeed(
+        seedColor: a.primaryColor,
+        brightness: a.darkMode ? Brightness.dark : Brightness.light,
+      ),
       cardTheme: CardThemeData(
-        // color: a.primaryColor.shade50,
         elevation: 0,
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(12.0),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,6 +9,5 @@ Future<void> main() async {
   /// Carrega a SharedPreferences antes de iniciar o app
   await SharedPreferences.getInstance();
 
-  /// Inicia o aplicativo principal
   runApp(const MainApp());
 }

--- a/lib/utils/widgets/base/wd_switch_theme.dart
+++ b/lib/utils/widgets/base/wd_switch_theme.dart
@@ -20,7 +20,7 @@ class WdSwitchTheme extends StatelessWidget {
       subtitle: Text('Atual: ${a.themeMode.$2}'),
       value: a.darkMode,
       shape: RoundedRectangleBorder(
-        side: BorderSide(width: 0, color: Colors.transparent),
+        side: BorderSide.none,
         borderRadius: BorderRadius.circular(12.0),
       ),
       isThreeLine: true,

--- a/lib/utils/widgets/base/wd_switch_theme.dart
+++ b/lib/utils/widgets/base/wd_switch_theme.dart
@@ -21,8 +21,9 @@ class WdSwitchTheme extends StatelessWidget {
       value: a.darkMode,
       shape: RoundedRectangleBorder(
         side: BorderSide(width: 0, color: Colors.transparent),
-        borderRadius: BorderRadius.circular(8.0),
+        borderRadius: BorderRadius.circular(12.0),
       ),
+      isThreeLine: true,
       thumbIcon: WidgetStateProperty.resolveWith<Icon?>((states) {
         if (a.darkMode) {
           return const Icon(Icons.nightlight_round);

--- a/lib/utils/widgets/base/wd_switch_theme.dart
+++ b/lib/utils/widgets/base/wd_switch_theme.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../../core/state/app_state.dart';
+
+class WdSwitchTheme extends StatelessWidget {
+  const WdSwitchTheme({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    /// Obtém, pelo provider, o estado do aplicativo
+    final AppState a = context.watch<AppState>();
+
+    return SwitchListTile(
+      contentPadding: const EdgeInsets.all(0),
+      title: Text(
+        'Tema do aplicativo',
+        style: Theme.of(context).textTheme.titleMedium,
+      ),
+      subtitle: Text('Atual: ${a.themeMode.$2}'),
+      value: a.darkMode,
+      shape: RoundedRectangleBorder(
+        side: BorderSide(width: 0, color: Colors.transparent),
+        borderRadius: BorderRadius.circular(8.0),
+      ),
+      thumbIcon: WidgetStateProperty.resolveWith<Icon?>((states) {
+        if (a.darkMode) {
+          return const Icon(Icons.nightlight_round);
+        } else {
+          return const Icon(Icons.wb_sunny);
+        }
+      }),
+      onChanged: (value) => a.toggleTheme(),
+    );
+  }
+}


### PR DESCRIPTION
Este pull request refatora e centraliza o gerenciamento de temas do aplicativo, melhora a experiência do usuário na troca de temas e garante a persistência das preferências de tema. As alterações introduzem uma classe dedicada `AppTheme`, atualizam o gerenciamento de estado para o modo de tema e aprimoram a interface de usuário de configurações para maior clareza e usabilidade.

**Gerenciamento e persistência de temas:**

* Foi introduzida uma nova classe `AppTheme` em `lib/core/theme/app_theme.dart` para centralizar a configuração do tema, suportando os modos claro e escuro e personalizando os estilos de texto e cartão. 
* `AppState` refatorado em `lib/core/state/app_state.dart` para gerenciar o modo de tema com armazenamento persistente usando `SharedPreferences`, e métodos atualizados para alternar e recuperar preferências de tema. 
* Adicionado um novo valor de enumeração `lightMode` em `CacheKeys` (`lib/core/enum/cache_keys.dart`) para armazenar e descrever a preferência de tema do usuário.

**Melhorias na interface do usuário para troca de temas:**

* Substituímos o antigo seletor de temas em `SettingRead` (`lib/app/home/tab/setting_read.dart`) por um novo widget reutilizável `WdSwitchTheme`, que oferece uma interface mais clara e exibe o modo de tema atual.
* O widget principal do aplicativo (`lib/app.dart`) foi atualizado para usar a nova classe `AppTheme` para temas claros e escuros, e para ler corretamente o modo do tema a partir do `AppState`.

Essas alterações, em conjunto, melhoram a consistência do tema, a persistência das preferências do usuário e a clareza da experiência de troca de temas.

### Ações
Closes #5 